### PR TITLE
added two new endpoints JGC

### DIFF
--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -152,6 +152,191 @@ paths:
           description: Bad request (invalid input data)
         '500':
           description: Internal server error
+
+  /positions/{id}/candidates:
+    get:
+      summary: Get candidates by position
+      description: Returns all candidates who have applied to a specific position, including their current interview step and average score.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the position
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: List of candidates for the position
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    candidateId:
+                      type: integer
+                      description: The unique identifier of the candidate
+                    fullName:
+                      type: string
+                      description: Full name of the candidate (firstName + lastName)
+                    email:
+                      type: string
+                      description: Email address of the candidate
+                    currentInterviewStep:
+                      type: object
+                      description: Current interview step for this candidate
+                      properties:
+                        id:
+                          type: integer
+                          description: ID of the interview step
+                        name:
+                          type: string
+                          description: Name of the interview step
+                        orderIndex:
+                          type: integer
+                          description: Order index of the step in the interview flow
+                    averageScore:
+                      type: number
+                      format: float
+                      nullable: true
+                      description: Average score of all interviews for this application (null if no interviews with scores)
+                    applicationDate:
+                      type: string
+                      format: date-time
+                      description: Date when the candidate applied
+                    candidate:
+                      type: object
+                      description: Complete candidate information
+                      properties:
+                        id:
+                          type: integer
+                        firstName:
+                          type: string
+                        lastName:
+                          type: string
+                        email:
+                          type: string
+                        phone:
+                          type: string
+                        address:
+                          type: string
+                        educations:
+                          type: array
+                          items:
+                            $ref: '#/components/schemas/Education'
+                        workExperiences:
+                          type: array
+                          items:
+                            $ref: '#/components/schemas/WorkExperience'
+                        resumes:
+                          type: array
+                          items:
+                            $ref: '#/components/schemas/Resume'
+        '400':
+          description: Bad request (invalid position ID)
+        '404':
+          description: Position not found
+        '500':
+          description: Internal server error
+
+  /positions/{id}/candidates/{candidateId}/stage:
+    put:
+      summary: Update candidate interview stage
+      description: Updates the current interview step for a specific candidate in a position.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the position
+          schema:
+            type: integer
+            format: int64
+        - name: candidateId
+          in: path
+          required: true
+          description: ID of the candidate
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - stageId
+              properties:
+                stageId:
+                  type: integer
+                  description: ID of the new interview step
+                notes:
+                  type: string
+                  description: Optional notes about the stage change
+      responses:
+        '200':
+          description: Candidate stage updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success message
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: ID of the application
+                      candidateId:
+                        type: integer
+                        description: ID of the candidate
+                      candidateName:
+                        type: string
+                        description: Full name of the candidate
+                      positionId:
+                        type: integer
+                        description: ID of the position
+                      positionTitle:
+                        type: string
+                        description: Title of the position
+                      previousStage:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: ID of the previous interview step
+                          name:
+                            type: string
+                            description: Name of the previous interview step
+                      currentStage:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: ID of the current interview step
+                          name:
+                            type: string
+                            description: Name of the current interview step
+                      applicationDate:
+                        type: string
+                        format: date-time
+                        description: Date when the candidate applied
+                      notes:
+                        type: string
+                        nullable: true
+                        description: Notes about the application
+        '400':
+          description: Bad request (invalid input data)
+        '404':
+          description: Resource not found (position, candidate, interview step, or application)
+        '500':
+          description: Internal server error
+
   /upload:
     post:
       summary: Upload a file
@@ -185,4 +370,56 @@ paths:
           description: Invalid file type, only PDF and DOCX are allowed
         '500':
           description: Error during the file upload process
+
+components:
+  schemas:
+    Education:
+      type: object
+      properties:
+        id:
+          type: integer
+        institution:
+          type: string
+        title:
+          type: string
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+          nullable: true
+    
+    WorkExperience:
+      type: object
+      properties:
+        id:
+          type: integer
+        company:
+          type: string
+        position:
+          type: string
+        description:
+          type: string
+          nullable: true
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+          nullable: true
+    
+    Resume:
+      type: object
+      properties:
+        id:
+          type: integer
+        filePath:
+          type: string
+        fileType:
+          type: string
+        uploadDate:
+          type: string
+          format: date-time
 

--- a/backend/src/application/services/applicationService.ts
+++ b/backend/src/application/services/applicationService.ts
@@ -1,0 +1,194 @@
+import { Position } from '../../domain/models/Position';
+import { Candidate } from '../../domain/models/Candidate';
+import { Application } from '../../domain/models/Application';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/**
+ * Obtiene los candidatos que han aplicado a una posición específica
+ * incluyendo información sobre su fase en el proceso y puntuación media
+ * @param positionId ID de la posición
+ * @returns Lista de candidatos con información ampliada
+ */
+export const getCandidatesByPosition = async (positionId: number): Promise<any[]> => {
+  try {
+    // Verificar que la posición existe
+    const position = await Position.findOne(positionId);
+    if (!position) {
+      throw new Error('La posición no existe');
+    }
+    
+    // Obtener aplicaciones con sus candidatos y entrevistas relacionadas
+    const applications = await prisma.application.findMany({
+      where: {
+        positionId: positionId
+      },
+      include: {
+        candidate: {
+          include: {
+            educations: true,
+            workExperiences: true,
+            resumes: true
+          }
+        },
+        interviewStep: true,
+        interviews: {
+          select: {
+            score: true
+          }
+        }
+      }
+    });
+    
+    // Construir respuesta con la información solicitada
+    const candidatesInfo = applications.map((app: any) => {
+      // Calcular puntuación media de las entrevistas
+      const scores = app.interviews
+        .map((interview: any) => interview.score)
+        .filter((score: any) => score !== null && score !== undefined) as number[];
+      
+      const averageScore = scores.length > 0
+        ? scores.reduce((sum: number, score: number) => sum + score, 0) / scores.length
+        : null;
+      
+      return {
+        candidateId: app.candidate.id,
+        fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+        email: app.candidate.email,
+        currentInterviewStep: {
+          id: app.interviewStep.id,
+          name: app.interviewStep.name,
+          orderIndex: app.interviewStep.orderIndex
+        },
+        averageScore: averageScore !== null ? Number(averageScore.toFixed(1)) : null,
+        applicationDate: app.applicationDate,
+        // Incluir información adicional del candidato según sea necesario
+        candidate: app.candidate
+      };
+    });
+    
+    return candidatesInfo;
+  } catch (error) {
+    console.error('Error al obtener candidatos por posición:', error);
+    throw error;
+  }
+};
+
+/**
+ * Crea una nueva aplicación para un candidato a una posición
+ * @param applicationData Datos de la aplicación
+ * @returns Aplicación creada
+ */
+export const createApplication = async (applicationData: {
+  positionId: number;
+  candidateId: number;
+  currentInterviewStep: number;
+  notes?: string;
+}): Promise<Application> => {
+  try {
+    // Verificar que la posición existe
+    const position = await Position.findOne(applicationData.positionId);
+    if (!position) {
+      throw new Error('La posición no existe');
+    }
+    
+    // Crear la aplicación con la fecha actual
+    const application = new Application({
+      ...applicationData,
+      applicationDate: new Date()
+    });
+    
+    return await application.save();
+  } catch (error) {
+    console.error('Error al crear la aplicación:', error);
+    throw error;
+  }
+};
+
+/**
+ * Actualiza la etapa de entrevista de un candidato en una posición específica
+ * @param positionId ID de la posición
+ * @param candidateId ID del candidato
+ * @param stageId ID de la nueva etapa de entrevista
+ * @param notes Notas opcionales sobre el cambio de etapa
+ * @returns La aplicación actualizada con la nueva etapa
+ */
+export const updateCandidateStage = async (
+  positionId: number,
+  candidateId: number,
+  stageId: number,
+  notes?: string
+): Promise<any> => {
+  try {
+    // Verificar que la posición existe
+    const position = await Position.findOne(positionId);
+    if (!position) {
+      throw new Error('La posición no existe');
+    }
+
+    // Verificar que el candidato existe
+    const candidate = await Candidate.findOne(candidateId);
+    if (!candidate) {
+      throw new Error('El candidato no existe');
+    }
+
+    // Verificar que la etapa de entrevista existe
+    const interviewStep = await prisma.interviewStep.findUnique({
+      where: { id: stageId }
+    });
+    if (!interviewStep) {
+      throw new Error('La etapa de entrevista no existe');
+    }
+
+    // Buscar la aplicación específica
+    const application = await prisma.application.findFirst({
+      where: {
+        positionId: positionId,
+        candidateId: candidateId
+      },
+      include: {
+        interviewStep: true
+      }
+    });
+
+    if (!application) {
+      throw new Error('No existe una aplicación para este candidato en esta posición');
+    }
+
+    // Actualizar la etapa
+    const updatedApplication = await prisma.application.update({
+      where: { id: application.id },
+      data: {
+        currentInterviewStep: stageId,
+        notes: notes !== undefined ? notes : application.notes
+      },
+      include: {
+        interviewStep: true,
+        candidate: true,
+        position: true
+      }
+    });
+
+    return {
+      id: updatedApplication.id,
+      candidateId: updatedApplication.candidateId,
+      candidateName: `${updatedApplication.candidate.firstName} ${updatedApplication.candidate.lastName}`,
+      positionId: updatedApplication.positionId,
+      positionTitle: updatedApplication.position.title,
+      previousStage: {
+        id: application.interviewStep.id,
+        name: application.interviewStep.name
+      },
+      currentStage: {
+        id: updatedApplication.interviewStep.id,
+        name: updatedApplication.interviewStep.name
+      },
+      applicationDate: updatedApplication.applicationDate,
+      notes: updatedApplication.notes
+    };
+  } catch (error) {
+    console.error('Error al actualizar la etapa del candidato:', error);
+    throw error;
+  }
+}; 

--- a/backend/src/application/services/positionService.ts
+++ b/backend/src/application/services/positionService.ts
@@ -1,0 +1,98 @@
+import { Position } from '../../domain/models/Position';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/**
+ * Obtiene todas las posiciones disponibles
+ * @param filters Filtros opcionales (status, companyId, etc.)
+ * @returns Lista de posiciones
+ */
+export const getAllPositions = async (filters?: {
+  status?: string;
+  companyId?: number;
+  isVisible?: boolean;
+}): Promise<Position[]> => {
+  try {
+    const whereClause: any = {};
+    
+    if (filters) {
+      if (filters.status) whereClause.status = filters.status;
+      if (filters.companyId) whereClause.companyId = filters.companyId;
+      if (filters.isVisible !== undefined) whereClause.isVisible = filters.isVisible;
+    }
+
+    const positions = await prisma.position.findMany({
+      where: whereClause,
+      include: {
+        company: true,
+        interviewFlow: true
+      }
+    });
+
+    return positions.map((positionData: any) => new Position(positionData));
+  } catch (error) {
+    console.error('Error al obtener las posiciones:', error);
+    throw new Error('Error al recuperar las posiciones');
+  }
+};
+
+/**
+ * Obtiene una posición por su ID
+ * @param id ID de la posición
+ * @returns Posición encontrada o null si no existe
+ */
+export const findPositionById = async (id: number): Promise<Position | null> => {
+  try {
+    const position = await Position.findOne(id);
+    return position;
+  } catch (error) {
+    console.error('Error al buscar la posición:', error);
+    throw new Error('Error al recuperar la posición');
+  }
+};
+
+/**
+ * Crea una nueva posición
+ * @param positionData Datos de la posición
+ * @returns Posición creada
+ */
+export const createPosition = async (positionData: Record<string, any>): Promise<Position> => {
+  try {
+    // Aquí podrías añadir validación de los datos de la posición
+    // similar a validateCandidateData en candidateService
+    
+    const position = new Position(positionData);
+    const savedPosition = await position.save();
+    return position;
+  } catch (error: any) {
+    console.error('Error al crear la posición:', error);
+    throw error;
+  }
+};
+
+/**
+ * Actualiza una posición existente
+ * @param id ID de la posición
+ * @param positionData Datos actualizados
+ * @returns Posición actualizada
+ */
+export const updatePosition = async (id: number, positionData: Record<string, any>): Promise<Position> => {
+  try {
+    const position = await Position.findOne(id);
+    if (!position) {
+      throw new Error('Posición no encontrada');
+    }
+
+    // Actualizar propiedades
+    for (const [key, value] of Object.entries(positionData)) {
+      (position as any)[key] = value;
+    }
+    
+    const updatedPosition = await position.save();
+    return position;
+  } catch (error) {
+    console.error('Error al actualizar la posición:', error);
+    throw error;
+  }
+}; 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import { PrismaClient } from '@prisma/client';
 import dotenv from 'dotenv';
 import candidateRoutes from './routes/candidateRoutes';
+import positionRoutes from './routes/positionRoutes';
 import { uploadFile } from './application/services/fileUploadService';
 import cors from 'cors';
 
@@ -38,6 +39,9 @@ app.use(cors({
 
 // Import and use candidateRoutes
 app.use('/candidates', candidateRoutes);
+
+// Import and use positionRoutes
+app.use('/positions', positionRoutes);
 
 // Route for file uploads
 app.post('/upload', uploadFile);

--- a/backend/src/presentation/controllers/positionController.ts
+++ b/backend/src/presentation/controllers/positionController.ts
@@ -1,0 +1,225 @@
+import { Request, Response } from 'express';
+import { 
+  getAllPositions, 
+  findPositionById, 
+  createPosition, 
+  updatePosition
+} from '../../application/services/positionService';
+import {
+  getCandidatesByPosition,
+  createApplication,
+  updateCandidateStage
+} from '../../application/services/applicationService';
+
+/**
+ * Obtiene todas las posiciones
+ */
+export const getPositionsController = async (req: Request, res: Response) => {
+  try {
+    // Extraer filtros de la query string
+    const filters: { 
+      status?: string; 
+      companyId?: number; 
+      isVisible?: boolean 
+    } = {};
+
+    if (req.query.status) filters.status = req.query.status as string;
+    if (req.query.companyId) filters.companyId = parseInt(req.query.companyId as string);
+    if (req.query.isVisible) filters.isVisible = (req.query.isVisible as string) === 'true';
+
+    const positions = await getAllPositions(filters);
+    res.status(200).json(positions);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      res.status(500).json({ message: 'Error obteniendo posiciones', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error obteniendo posiciones', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Obtiene una posición por su ID
+ */
+export const getPositionByIdController = async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({ error: 'ID de posición inválido' });
+    }
+
+    const position = await findPositionById(id);
+    if (!position) {
+      return res.status(404).json({ error: 'Posición no encontrada' });
+    }
+
+    res.status(200).json(position);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      res.status(500).json({ message: 'Error obteniendo posición', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error obteniendo posición', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Crea una nueva posición
+ */
+export const createPositionController = async (req: Request, res: Response) => {
+  try {
+    const positionData = req.body;
+    const position = await createPosition(positionData);
+    res.status(201).json({ 
+      message: 'Posición creada exitosamente', 
+      data: position 
+    });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      res.status(400).json({ message: 'Error creando posición', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error creando posición', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Actualiza una posición existente
+ */
+export const updatePositionController = async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({ error: 'ID de posición inválido' });
+    }
+
+    const positionData = req.body;
+    const position = await updatePosition(id, positionData);
+    
+    res.status(200).json({ 
+      message: 'Posición actualizada exitosamente', 
+      data: position 
+    });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === 'Posición no encontrada') {
+        return res.status(404).json({ error: error.message });
+      }
+      res.status(400).json({ message: 'Error actualizando posición', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error actualizando posición', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Obtiene los candidatos que han aplicado a una posición específica
+ */
+export const getCandidatesByPositionController = async (req: Request, res: Response) => {
+  try {
+    const positionId = parseInt(req.params.id);
+    if (isNaN(positionId)) {
+      return res.status(400).json({ error: 'ID de posición inválido' });
+    }
+    
+    const candidates = await getCandidatesByPosition(positionId);
+    res.status(200).json(candidates);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === 'La posición no existe') {
+        return res.status(404).json({ error: error.message });
+      }
+      res.status(500).json({ message: 'Error obteniendo candidatos', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error obteniendo candidatos', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Actualiza la etapa de entrevista de un candidato en una posición
+ */
+export const updateCandidateStageController = async (req: Request, res: Response) => {
+  try {
+    const positionId = parseInt(req.params.id);
+    const candidateId = parseInt(req.params.candidateId);
+    const { stageId, notes } = req.body;
+    
+    if (isNaN(positionId)) {
+      return res.status(400).json({ error: 'ID de posición inválido' });
+    }
+    
+    if (isNaN(candidateId)) {
+      return res.status(400).json({ error: 'ID de candidato inválido' });
+    }
+    
+    if (!stageId || isNaN(parseInt(stageId.toString()))) {
+      return res.status(400).json({ error: 'ID de etapa inválido o no proporcionado' });
+    }
+    
+    const result = await updateCandidateStage(
+      positionId,
+      candidateId,
+      parseInt(stageId.toString()),
+      notes
+    );
+    
+    res.status(200).json({
+      message: 'Etapa del candidato actualizada exitosamente',
+      data: result
+    });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (
+        error.message === 'La posición no existe' ||
+        error.message === 'El candidato no existe' ||
+        error.message === 'La etapa de entrevista no existe' ||
+        error.message === 'No existe una aplicación para este candidato en esta posición'
+      ) {
+        return res.status(404).json({ error: error.message });
+      }
+      res.status(400).json({ message: 'Error actualizando etapa del candidato', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error actualizando etapa del candidato', error: 'Error desconocido' });
+    }
+  }
+};
+
+/**
+ * Crea una nueva aplicación para un candidato a una posición
+ */
+export const createApplicationController = async (req: Request, res: Response) => {
+  try {
+    const { candidateId, currentInterviewStep, notes } = req.body;
+    const positionId = parseInt(req.params.id);
+
+    if (isNaN(positionId)) {
+      return res.status(400).json({ error: 'ID de posición inválido' });
+    }
+
+    if (!candidateId || !currentInterviewStep) {
+      return res.status(400).json({ error: 'Faltan datos obligatorios para la aplicación' });
+    }
+
+    const application = await createApplication({
+      positionId,
+      candidateId,
+      currentInterviewStep,
+      notes
+    });
+    
+    res.status(201).json({ 
+      message: 'Aplicación creada exitosamente', 
+      data: application 
+    });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === 'La posición no existe') {
+        return res.status(404).json({ error: error.message });
+      }
+      res.status(400).json({ message: 'Error creando aplicación', error: error.message });
+    } else {
+      res.status(500).json({ message: 'Error creando aplicación', error: 'Error desconocido' });
+    }
+  }
+}; 

--- a/backend/src/routes/positionRoutes.ts
+++ b/backend/src/routes/positionRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { 
+  getPositionsController, 
+  getPositionByIdController, 
+  createPositionController, 
+  updatePositionController,
+  getCandidatesByPositionController,
+  createApplicationController,
+  updateCandidateStageController
+} from '../presentation/controllers/positionController';
+
+const router = Router();
+
+// Rutas principales de posiciones
+router.get('/', getPositionsController);
+router.get('/:id', getPositionByIdController);
+router.post('/', createPositionController);
+router.put('/:id', updatePositionController);
+
+// Rutas relacionadas con candidatos y aplicaciones
+router.get('/:id/candidates', getCandidatesByPositionController);
+router.post('/:id/applications', createApplicationController);
+router.put('/:id/candidates/:candidateId/stage', updateCandidateStageController);
+
+export default router; 

--- a/prompts/prompts-JGC.md
+++ b/prompts/prompts-JGC.md
@@ -1,0 +1,37 @@
+# Prompt 1 (claude-3.7-sonnet)
+Eres un experto arquitecto de sistemas con experiencia en ATS y en API REST. Genérame una documentación que incluya la estructura de carpetas, las tecnologías utilizadas, la arquitectura y el contrato del API Rest de @backend.
+
+Hazlo en español y dame la salida en formato markdown, en un nuevo fichero backend.md
+___
+# Prompt 2 (claude-3.7-sonnet)
+Eres un experto en bases de datos. Dame una documentación del modelo de datos que explique campos, relaciones y un diagrama en formato mermaid @prisma
+___
+# Prompt 3 (claude-3.7-sonnet)
+Perfecto. Teniendo en cuenta ahora toda la documentación en @backend.md y también el @modelo_datos.md , quiero generar un nuevo endpoint para obtener todos los candidatos que aplican a una determinada posición. ¿Qué cosas necesito implementar previamente para este objetivo? ¿Tal vez deba implementar primero un endpoint para obtener las posiciones actuales?
+
+No implementes nada todavía, solo explícame qué pasos debería dar para conseguir mi objetivo
+___
+# Prompt 4 (claude-3.7-sonnet)
+Perfecto. Comienza con el servicio de posiciones. Sé coherente con la implementación de otros servicios similares, como @candidateService.ts y aplica las buenas prácticas de clean code y DDD, que conoces bien como experto en ingeniero de software y arquitecto de sofwate con más de 20 años de experiencia en el sector
+___
+# Prompt 5 (claude-3.7-sonnet)
+1. Asegúrate de que el nuevo endpoint (GET /positions/:id/candidates) proporciona la siguiente información básica:
+      - Nombre completo del candidato (de la tabla candidate).
+      - current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+      - La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score
+
+2. Actualiza también el @api-spec.yaml documentando el nuevo endpoint
+___
+# Prompt 6 (claude-3.7-sonnet)
+las funciones para obtener los candidatos que aplicado a una posición específica (getCandidatesByPosition) y para crear una nueva aplicación para un candidato a una posición (createApplication) los has implementado en @positionService.ts. Siguiente los principios SOLID y DRY, ¿sería esa su ubicación correcta? ¿No deberían ir en nuevo servicio de nombre, por ejemplo, applicationService.ts?
+
+Si crees que es así, traslada estas funciones a un servicio específico para aplicaciones. No hagas nada más que no sea estrictamente necesario. En caso de hacerlo, avísame antes para decidir
+___
+# Prompt 7 (claude-3.7-sonnet)
+Ahora quiero implementar un nuevo endpoint: PUT /positions/:id/candidates/:id/stage, para modificar la fase actual del proceso de entrevista en la que se encuentra un candidato específico en una posición determinada.
+
+Implementa el nuevo endpoint en el controlador @positionController.ts , añadiendo la funcionalidad necesaria al servicio @applicationService.ts y actualizar las rutas y la documentación en @api-spec.yaml
+___
+# Prompt 8 (claude-3.7-sonnet)
+
+


### PR DESCRIPTION
feat: añadir endpoints para la gestión de candidatos y posiciones

Se han añadido los siguientes endpoints:

- **Posiciones:**
  - GET `/positions/{id}/candidates`: Obtener todos los candidatos que han aplicado a una posición específica
  - PUT `/positions/{id}/candidates/{candidateId}/stage`: Actualizar la etapa de entrevista de un candidato en una posición

Además, se ha creado la documentación de la API con ejemplos de solicitudes y respuestas para facilitar su uso.

La implementación incluye validación de datos y manejo de errores para asegurar la integridad de la información en el sistema. 